### PR TITLE
Serialize rest-json error headers

### DIFF
--- a/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
+++ b/codegen/smithy-aws-typescript-codegen/src/main/java/software/amazon/smithy/aws/typescript/codegen/RestJsonProtocolGenerator.java
@@ -91,6 +91,12 @@ abstract class RestJsonProtocolGenerator extends HttpBindingProtocolGenerator {
     }
 
     @Override
+    protected void writeDefaultErrorHeaders(GenerationContext context, StructureShape error) {
+        super.writeDefaultErrorHeaders(context, error);
+        context.getWriter().write("'x-amzn-errortype': $S,", error.getId().getName());
+    }
+
+    @Override
     public void serializeInputDocument(
             GenerationContext context,
             OperationShape operation,


### PR DESCRIPTION
This serializes the error code header for rest-json. This should unblock actually using a generated client to interact with the whole modeled experience.

---
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
